### PR TITLE
feat: Claude service — signature extraction and text transformation

### DIFF
--- a/core/services/claude.py
+++ b/core/services/claude.py
@@ -1,0 +1,166 @@
+"""
+Claude AI service.
+
+All Anthropic SDK calls are isolated here — no other module may import
+``anthropic`` directly.
+
+Public functions
+----------------
+extract_signature(texts)  — derive a tone-of-voice signature from brand documents
+transform_text(text, signature)  — rewrite text applying a stored signature
+"""
+
+import json
+import logging
+import os
+from typing import Any
+
+import anthropic
+
+logger = logging.getLogger(__name__)
+
+MODEL = "claude-sonnet-4-6"
+
+SIGNATURE_KEYS = {"tone", "sentence_rhythm", "formality_level", "forms_of_address", "emotional_appeal"}
+
+EXTRACTION_SYSTEM = """\
+You are a brand voice analyst. Your task is to analyze a set of brand documents
+and extract a structured tone-of-voice signature as JSON.
+
+Return ONLY valid JSON with exactly these five keys — no preamble, no markdown fences,
+no explanation:
+
+{
+  "tone": "...",
+  "sentence_rhythm": "...",
+  "formality_level": "...",
+  "forms_of_address": "...",
+  "emotional_appeal": "..."
+}
+
+Key definitions (these scopes must not overlap):
+- tone: The emotional register and personality of the voice — how it feels to read this brand.
+  Do NOT describe sentence structure or grammar here.
+- sentence_rhythm: The structural preference — sentence length, pacing, use of fragments,
+  parallelism, punctuation cadence. Do NOT describe emotional register here.
+- formality_level: Position on the spectrum from intimate/conversational to institutional/formal.
+  Do NOT conflate with tone or personality.
+- forms_of_address: Grammatical person and pronouns the brand uses — how it refers to itself
+  (we/I/none) and how it addresses the reader (you/one/your team/etc.).
+  Do NOT describe emotional register here.
+- emotional_appeal: The primary persuasion mode — where it sits on the rational-to-emotional axis,
+  and what feelings or logic it activates. Do NOT describe tone personality here.
+
+Each value must be a single descriptive sentence or short phrase. Be specific and precise.\
+"""
+
+TRANSFORMATION_SYSTEM = """\
+You are a brand voice editor. Rewrite the user's text so it matches the provided
+tone-of-voice signature exactly. Preserve the original meaning and all factual content.
+Return ONLY the rewritten text — no preamble, no explanation, no quotation marks around it.\
+"""
+
+
+class ClaudeServiceError(Exception):
+    """Raised when the Claude API returns an error or an unexpected response."""
+
+
+def extract_signature(texts: list[str]) -> dict[str, Any]:
+    """Analyze brand document texts and return a tone-of-voice signature.
+
+    Parameters
+    ----------
+    texts:
+        A list of extracted plain-text strings from brand documents.
+
+    Returns
+    -------
+    dict
+        A dict with exactly five keys: ``tone``, ``sentence_rhythm``,
+        ``formality_level``, ``forms_of_address``, ``emotional_appeal``.
+
+    Raises
+    ------
+    ClaudeServiceError
+        On Anthropic API failure, malformed JSON response, or missing keys.
+    """
+    combined = "\n\n---\n\n".join(texts)
+    prompt = f"Analyze the following brand documents and extract the tone-of-voice signature:\n\n{combined}"
+
+    raw = _call_claude(system=EXTRACTION_SYSTEM, user=prompt)
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.error("Claude returned malformed JSON: %s", raw)
+        raise ClaudeServiceError(f"Claude returned malformed JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        logger.error("Claude response is not a JSON object: %s", raw)
+        raise ClaudeServiceError("Claude response is not a JSON object.")
+
+    missing = SIGNATURE_KEYS - data.keys()
+    if missing:
+        logger.error("Claude response missing keys %s: %s", missing, raw)
+        raise ClaudeServiceError(f"Claude response is missing required keys: {missing}")
+
+    return {key: data[key] for key in SIGNATURE_KEYS}
+
+
+def transform_text(text: str, signature: dict[str, Any]) -> str:
+    """Rewrite *text* applying the given tone-of-voice *signature*.
+
+    Parameters
+    ----------
+    text:
+        The input text to rewrite.
+    signature:
+        A tone-of-voice signature dict as returned by :func:`extract_signature`.
+
+    Returns
+    -------
+    str
+        The rewritten text in the brand's voice.
+
+    Raises
+    ------
+    ClaudeServiceError
+        On Anthropic API failure or an empty response.
+    """
+    signature_block = "\n".join(f"- {key}: {value}" for key, value in signature.items())
+    prompt = (
+        f"Tone-of-voice signature:\n{signature_block}\n\n"
+        f"Text to rewrite:\n{text}"
+    )
+
+    result = _call_claude(system=TRANSFORMATION_SYSTEM, user=prompt)
+    if not result.strip():
+        raise ClaudeServiceError("Claude returned an empty transformation response.")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helper
+# ---------------------------------------------------------------------------
+
+def _call_claude(system: str, user: str) -> str:
+    """Send a single message to Claude and return the text content.
+
+    Raises
+    ------
+    ClaudeServiceError
+        On any Anthropic API exception.
+    """
+    try:
+        client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+        message = client.messages.create(
+            model=MODEL,
+            max_tokens=1024,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+        )
+        return message.content[0].text
+    except anthropic.APIError as exc:
+        raise ClaudeServiceError(f"Anthropic API error: {exc}") from exc
+    except Exception as exc:
+        raise ClaudeServiceError(f"Unexpected error calling Claude: {exc}") from exc

--- a/core/tests/test_services.py
+++ b/core/tests/test_services.py
@@ -1,0 +1,104 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from core.services.claude import ClaudeServiceError, extract_signature, transform_text
+
+VALID_SIGNATURE = {
+    "tone": "authoritative yet approachable",
+    "sentence_rhythm": "short declaratives followed by one elaborating clause",
+    "formality_level": "semi-formal — professional enough for B2B, human enough to avoid stiffness",
+    "forms_of_address": "second person singular (you / your); occasional we-inclusive",
+    "emotional_appeal": "rational-first with aspirational payoff; benefits before feelings",
+}
+
+MOCK_PATH = "core.services.claude.anthropic.Anthropic"
+
+
+def _mock_client(response_text: str) -> MagicMock:
+    """Return a mock Anthropic client that yields *response_text*."""
+    content_block = MagicMock()
+    content_block.text = response_text
+    message = MagicMock()
+    message.content = [content_block]
+    client = MagicMock()
+    client.messages.create.return_value = message
+    return client
+
+
+class ExtractSignatureTests(TestCase):
+    @patch(MOCK_PATH)
+    def test_returns_dict_with_all_five_keys(self, mock_cls) -> None:
+        import json
+        mock_cls.return_value = _mock_client(json.dumps(VALID_SIGNATURE))
+        result = extract_signature(["Sample brand text."])
+        self.assertEqual(set(result.keys()), {
+            "tone", "sentence_rhythm", "formality_level", "forms_of_address", "emotional_appeal"
+        })
+
+    @patch(MOCK_PATH)
+    def test_extra_keys_stripped(self, mock_cls) -> None:
+        import json
+        extra = {**VALID_SIGNATURE, "unexpected_key": "ignored"}
+        mock_cls.return_value = _mock_client(json.dumps(extra))
+        result = extract_signature(["Sample brand text."])
+        self.assertNotIn("unexpected_key", result)
+
+    @patch(MOCK_PATH)
+    def test_malformed_json_raises(self, mock_cls) -> None:
+        mock_cls.return_value = _mock_client("This is not JSON at all.")
+        with self.assertRaises(ClaudeServiceError) as ctx:
+            extract_signature(["Sample brand text."])
+        self.assertIn("malformed JSON", str(ctx.exception))
+
+    @patch(MOCK_PATH)
+    def test_missing_keys_raises(self, mock_cls) -> None:
+        import json
+        incomplete = {"tone": "friendly", "sentence_rhythm": "short"}
+        mock_cls.return_value = _mock_client(json.dumps(incomplete))
+        with self.assertRaises(ClaudeServiceError) as ctx:
+            extract_signature(["Sample brand text."])
+        self.assertIn("missing required keys", str(ctx.exception))
+
+    @patch(MOCK_PATH)
+    def test_api_failure_raises(self, mock_cls) -> None:
+        import anthropic
+        mock_cls.return_value.messages.create.side_effect = anthropic.APIError(
+            message="upstream error", request=MagicMock(), body=None
+        )
+        with self.assertRaises(ClaudeServiceError) as ctx:
+            extract_signature(["Sample brand text."])
+        self.assertIn("Anthropic API error", str(ctx.exception))
+
+    @patch(MOCK_PATH)
+    def test_non_object_response_raises(self, mock_cls) -> None:
+        import json
+        mock_cls.return_value = _mock_client(json.dumps(["list", "not", "object"]))
+        with self.assertRaises(ClaudeServiceError) as ctx:
+            extract_signature(["Sample brand text."])
+        self.assertIn("not a JSON object", str(ctx.exception))
+
+
+class TransformTextTests(TestCase):
+    @patch(MOCK_PATH)
+    def test_returns_rewritten_string(self, mock_cls) -> None:
+        mock_cls.return_value = _mock_client("Rewritten text in brand voice.")
+        result = transform_text("Original text.", VALID_SIGNATURE)
+        self.assertEqual(result, "Rewritten text in brand voice.")
+
+    @patch(MOCK_PATH)
+    def test_api_failure_raises(self, mock_cls) -> None:
+        import anthropic
+        mock_cls.return_value.messages.create.side_effect = anthropic.APIError(
+            message="upstream error", request=MagicMock(), body=None
+        )
+        with self.assertRaises(ClaudeServiceError) as ctx:
+            transform_text("Original text.", VALID_SIGNATURE)
+        self.assertIn("Anthropic API error", str(ctx.exception))
+
+    @patch(MOCK_PATH)
+    def test_empty_response_raises(self, mock_cls) -> None:
+        mock_cls.return_value = _mock_client("   ")
+        with self.assertRaises(ClaudeServiceError) as ctx:
+            transform_text("Original text.", VALID_SIGNATURE)
+        self.assertIn("empty", str(ctx.exception))


### PR DESCRIPTION
## Summary
  - `core/services/claude.py` — the only module that imports `anthropic`
  - `extract_signature(texts)` — sends all brand document texts to Claude, returns dict with exactly 5 keys
  - `transform_text(text, signature)` — rewrites input text applying the stored signature
  - `ClaudeServiceError` raised on API failure, malformed JSON, missing keys, or empty response
  - Extraction prompt defines each signature characteristic boundary explicitly to prevent bleed-through
  - Model pinned to `claude-sonnet-4-6`

  ## Checklist
  - [x] `extract_signature()` returns a dict with exactly the 5 expected keys
  - [x] `transform_text()` returns a non-empty string
  - [x] Extraction prompt defines all 5 characteristic boundaries explicitly
  - [x] `ClaudeServiceError` raised (not a raw exception) on all failure modes
  - [x] 9 tests — zero live Anthropic calls, Anthropic client mocked throughout
  - [x] `manage.py check` — 0 issues

  Closes #5