### PR TITLE
feat: Django Templates UI — upload, transform, and base layout

### DIFF
--- a/core/static/css/main.css
+++ b/core/static/css/main.css
@@ -1,0 +1,285 @@
+/* -----------------------------------------------------------------------
+   Tone-of-Voice — minimal stylesheet
+   ----------------------------------------------------------------------- */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  --color-bg: #f9f9f9;
+  --color-surface: #ffffff;
+  --color-border: #e0e0e0;
+  --color-text: #1a1a1a;
+  --color-muted: #6b6b6b;
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-danger: #dc2626;
+  --color-danger-hover: #b91c1c;
+  --color-success-bg: #f0fdf4;
+  --color-success-border: #86efac;
+  --color-success-text: #166534;
+  --color-error-bg: #fef2f2;
+  --color-error-border: #fca5a5;
+  --color-error-text: #991b1b;
+  --color-warn-bg: #fffbeb;
+  --color-warn-border: #fcd34d;
+  --radius: 6px;
+  --shadow: 0 1px 3px rgba(0,0,0,.08);
+}
+
+html { font-size: 16px; }
+
+body {
+  font-family: var(--font);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+/* --- Nav --- */
+
+header {
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  padding: 0 2rem;
+}
+
+nav {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  height: 56px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.nav-brand {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+nav ul {
+  display: flex;
+  list-style: none;
+  gap: 1.5rem;
+}
+
+nav ul a {
+  color: var(--color-muted);
+  text-decoration: none;
+  font-size: .9rem;
+}
+
+nav ul a:hover { color: var(--color-text); }
+
+/* --- Main --- */
+
+main {
+  max-width: 1100px;
+  margin: 2rem auto;
+  padding: 0 2rem;
+}
+
+/* --- Messages --- */
+
+.messages { display: flex; flex-direction: column; gap: .5rem; margin-bottom: 1.5rem; }
+
+.message {
+  padding: .75rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid;
+  font-size: .9rem;
+}
+
+.message--success {
+  background: var(--color-success-bg);
+  border-color: var(--color-success-border);
+  color: var(--color-success-text);
+}
+
+.message--error {
+  background: var(--color-error-bg);
+  border-color: var(--color-error-border);
+  color: var(--color-error-text);
+}
+
+/* --- Page header --- */
+
+.page-header { margin-bottom: 1.5rem; }
+.page-header h1 { font-size: 1.6rem; }
+.page-header .subtitle { color: var(--color-muted); margin-top: .25rem; }
+
+/* --- Card --- */
+
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.card h2 { font-size: 1.1rem; margin-bottom: 1rem; }
+
+/* --- Section header (heading + button side by side) --- */
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.section-header h2 { margin-bottom: 0; }
+
+/* --- Forms --- */
+
+.form-row { margin-bottom: 1rem; }
+.form-row label { display: block; font-size: .85rem; font-weight: 600; margin-bottom: .35rem; color: var(--color-muted); }
+.form-row--file { display: flex; gap: .75rem; align-items: center; }
+
+select, textarea, input[type="file"] {
+  width: 100%;
+  padding: .5rem .75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-family: var(--font);
+  font-size: .95rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+select { cursor: pointer; }
+textarea { resize: vertical; }
+
+.form-inline { display: inline; }
+
+/* --- Buttons --- */
+
+.btn {
+  display: inline-block;
+  padding: .45rem 1rem;
+  border: none;
+  border-radius: var(--radius);
+  font-size: .9rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.btn:disabled { opacity: .45; cursor: not-allowed; }
+
+.btn--primary { background: var(--color-primary); color: #fff; }
+.btn--primary:hover:not(:disabled) { background: var(--color-primary-hover); }
+
+.btn--secondary { background: var(--color-surface); color: var(--color-text); border: 1px solid var(--color-border); }
+.btn--secondary:hover:not(:disabled) { background: var(--color-bg); }
+
+.btn--danger { background: var(--color-danger); color: #fff; }
+.btn--danger:hover:not(:disabled) { background: var(--color-danger-hover); }
+
+.btn--sm { padding: .25rem .6rem; font-size: .8rem; }
+
+/* --- Table --- */
+
+table { width: 100%; border-collapse: collapse; font-size: .9rem; }
+th { text-align: left; font-size: .8rem; font-weight: 600; color: var(--color-muted); padding: .5rem .75rem; border-bottom: 2px solid var(--color-border); }
+td { padding: .6rem .75rem; border-bottom: 1px solid var(--color-border); vertical-align: middle; }
+tr:last-child td { border-bottom: none; }
+
+/* --- Badge --- */
+
+.badge {
+  display: inline-block;
+  padding: .1rem .5rem;
+  border-radius: 999px;
+  font-size: .75rem;
+  font-weight: 600;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  color: var(--color-muted);
+  text-transform: uppercase;
+}
+
+.badge--warn {
+  background: var(--color-warn-bg);
+  border-color: var(--color-warn-border);
+  color: #92400e;
+}
+
+/* --- Signature box / used --- */
+
+.signature-box, .signature-used {
+  margin-top: 1.5rem;
+  padding: 1rem 1.25rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+}
+
+.signature-box h3, .signature-used h3 {
+  font-size: .85rem;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--color-muted);
+  margin-bottom: .75rem;
+}
+
+dl { display: grid; grid-template-columns: max-content 1fr; gap: .4rem 1rem; }
+dt { font-weight: 600; font-size: .85rem; color: var(--color-muted); white-space: nowrap; }
+dd { font-size: .9rem; }
+
+/* --- Notice (no signature yet) --- */
+
+.notice {
+  padding: .75rem 1rem;
+  background: var(--color-warn-bg);
+  border: 1px solid var(--color-warn-border);
+  border-radius: var(--radius);
+  font-size: .9rem;
+  margin-bottom: 1rem;
+}
+
+/* --- Comparison panel --- */
+
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-top: 1.25rem;
+}
+
+.comparison__col h3 {
+  font-size: .85rem;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--color-muted);
+  margin-bottom: .5rem;
+}
+
+.text-block {
+  font-family: var(--mono);
+  font-size: .85rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  line-height: 1.6;
+}
+
+/* --- Misc --- */
+
+.empty { color: var(--color-muted); font-size: .9rem; padding: .5rem 0; }
+.hint  { color: var(--color-muted); font-size: .85rem; margin-bottom: .75rem; }
+
+@media (max-width: 700px) {
+  .comparison { grid-template-columns: 1fr; }
+  .section-header { flex-direction: column; align-items: flex-start; gap: .75rem; }
+}

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}Tone-of-Voice{% endblock %}</title>
+  {% load static %}
+  <link rel="stylesheet" href="{% static 'css/main.css' %}">
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="/" class="nav-brand">Tone-of-Voice</a>
+      <ul>
+        <li><a href="/">Upload</a></li>
+        <li><a href="/transform/">Transform</a></li>
+        <li><a href="/api/schema/swagger-ui/" target="_blank">API Docs</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    {% if messages %}
+      <div class="messages">
+        {% for message in messages %}
+          <div class="message message--{{ message.tags }}">{{ message }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/core/templates/transform.html
+++ b/core/templates/transform.html
@@ -1,0 +1,77 @@
+{% extends "base.html" %}
+{% block title %}Transform — Tone-of-Voice{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Transform Text</h1>
+  <p class="subtitle">Rewrite any text in your brand's tone-of-voice.</p>
+</div>
+
+<section class="card">
+  <form method="post" action="/transform/">
+    {% csrf_token %}
+
+    <div class="form-row">
+      <label for="brand-select">Brand</label>
+      <select name="brand_id" id="brand-select">
+        <option value="">— choose a brand —</option>
+        {% for b in brands %}
+          <option value="{{ b.pk }}" {% if brand and brand.pk == b.pk %}selected{% endif %}>
+            {{ b.name }}{% if not b.signature %} (no signature){% endif %}
+          </option>
+        {% endfor %}
+      </select>
+    </div>
+
+    {% if brand and not brand.signature %}
+    <div class="notice">
+      No signature found for <strong>{{ brand.name }}</strong>.
+      Go to <a href="/?brand={{ brand.pk }}">Upload</a>, add documents, and click
+      <em>Extract signature</em> first.
+    </div>
+    {% endif %}
+
+    <div class="form-row">
+      <label for="text-input">Text to rewrite</label>
+      <textarea name="text" id="text-input" rows="6"
+        placeholder="Paste any text here — a draft email, a product description, a social post…">{{ request.POST.text }}</textarea>
+    </div>
+
+    <div class="form-row">
+      <button type="submit" class="btn btn--primary"
+        {% if brand and not brand.signature %}disabled{% endif %}>
+        Transform
+      </button>
+    </div>
+  </form>
+</section>
+
+{% if original %}
+<section class="card">
+  <h2>Result</h2>
+
+  {% if brand.signature %}
+  <div class="signature-used">
+    <h3>Signature applied</h3>
+    <dl>
+      {% for key, value in brand.signature.items %}
+        <dt>{{ key|title|cut:"_" }}</dt>
+        <dd>{{ value }}</dd>
+      {% endfor %}
+    </dl>
+  </div>
+  {% endif %}
+
+  <div class="comparison">
+    <div class="comparison__col">
+      <h3>Original</h3>
+      <pre class="text-block">{{ original }}</pre>
+    </div>
+    <div class="comparison__col">
+      <h3>Transformed</h3>
+      <pre class="text-block">{{ transformed }}</pre>
+    </div>
+  </div>
+</section>
+{% endif %}
+{% endblock %}

--- a/core/templates/upload.html
+++ b/core/templates/upload.html
@@ -1,0 +1,104 @@
+{% extends "base.html" %}
+{% block title %}Upload — Tone-of-Voice{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Upload Documents</h1>
+  <p class="subtitle">Upload brand content, then extract its tone-of-voice signature.</p>
+</div>
+
+<section class="card">
+  <h2>Select brand</h2>
+  <form method="get" action="/">
+    <div class="form-row">
+      <select name="brand" id="brand-select" onchange="this.form.submit()">
+        <option value="">— choose a brand —</option>
+        {% for b in brands %}
+          <option value="{{ b.pk }}" {% if brand and brand.pk == b.pk %}selected{% endif %}>
+            {{ b.name }}
+          </option>
+        {% endfor %}
+      </select>
+    </div>
+  </form>
+</section>
+
+{% if brand %}
+<section class="card">
+  <h2>Upload a file</h2>
+  <p class="hint">Accepted: PDF, DOCX, TXT, PNG &mdash; max 20 MB.</p>
+  <form method="post" action="/" enctype="multipart/form-data">
+    {% csrf_token %}
+    <input type="hidden" name="brand_id" value="{{ brand.pk }}">
+    <input type="hidden" name="action" value="upload">
+    <div class="form-row form-row--file">
+      <input type="file" name="file" id="file-input" accept=".pdf,.docx,.txt,.png" required>
+      <button type="submit" class="btn btn--primary">Upload</button>
+    </div>
+  </form>
+</section>
+
+<section class="card">
+  <div class="section-header">
+    <h2>Documents for {{ brand.name }}</h2>
+    <form method="post" action="/">
+      {% csrf_token %}
+      <input type="hidden" name="brand_id" value="{{ brand.pk }}">
+      <input type="hidden" name="action" value="extract">
+      <button type="submit" class="btn btn--secondary"
+        {% if not documents %}disabled title="Upload at least one document first"{% endif %}>
+        Extract signature
+      </button>
+    </form>
+  </div>
+
+  {% if documents %}
+    <table>
+      <thead>
+        <tr>
+          <th>Filename</th>
+          <th>Type</th>
+          <th>Truncated</th>
+          <th>Uploaded</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for doc in documents %}
+        <tr>
+          <td>{{ doc.filename }}</td>
+          <td><span class="badge">{{ doc.file_type }}</span></td>
+          <td>{% if doc.truncated %}<span class="badge badge--warn">yes</span>{% else %}no{% endif %}</td>
+          <td>{{ doc.uploaded_at|date:"Y-m-d H:i" }}</td>
+          <td>
+            <form method="post" action="/" class="form-inline">
+              {% csrf_token %}
+              <input type="hidden" name="brand_id" value="{{ brand.pk }}">
+              <input type="hidden" name="action" value="delete">
+              <input type="hidden" name="document_id" value="{{ doc.pk }}">
+              <button type="submit" class="btn btn--danger btn--sm"
+                onclick="return confirm('Delete {{ doc.filename }}?')">Delete</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="empty">No documents uploaded yet.</p>
+  {% endif %}
+
+  {% if brand.signature %}
+  <div class="signature-box">
+    <h3>Current signature</h3>
+    <dl>
+      {% for key, value in brand.signature.items %}
+        <dt>{{ key|title|cut:"_" }}</dt>
+        <dd>{{ value }}</dd>
+      {% endfor %}
+    </dl>
+  </div>
+  {% endif %}
+</section>
+{% endif %}
+{% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -1,3 +1,201 @@
-from django.shortcuts import render
+"""
+Django template views for the Tone-of-Voice UI.
 
-# Create your views here.
+/            — upload.html  — upload documents, trigger extraction
+/transform/  — transform.html — rewrite text in a brand's voice
+"""
+
+import logging
+from typing import Any
+
+from django.contrib import messages
+from django.shortcuts import get_object_or_404, redirect, render
+from django.views.decorators.http import require_GET, require_http_methods, require_POST
+
+from core.models import Brand, Document
+from core.services.claude import ClaudeServiceError, extract_signature, transform_text
+from core.services.extraction import extract_text
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_EXTENSIONS = frozenset({"pdf", "docx", "txt", "png"})
+MAX_UPLOAD_BYTES = 20 * 1024 * 1024  # 20 MB
+
+MIME_MAGIC: dict[str, bytes] = {
+    "pdf": b"%PDF",
+    "png": b"\x89PNG",
+    "docx": b"PK",
+}
+
+
+def _ctx(request, **extra: Any) -> dict[str, Any]:
+    """Build base template context: all brands + any extra kwargs."""
+    return {"brands": Brand.objects.all().order_by("name"), **extra}
+
+
+# ---------------------------------------------------------------------------
+# Upload view  /
+# ---------------------------------------------------------------------------
+
+@require_http_methods(["GET", "POST"])
+def upload_view(request):
+    """Upload view — document upload, list, and signature extraction.
+
+    GET  — render upload form with optional brand selection.
+    POST — handle file upload, document deletion, or signature extraction.
+    """
+    brand_id = request.GET.get("brand") or request.POST.get("brand_id")
+    brand = None
+    if brand_id:
+        brand = get_object_or_404(Brand, pk=brand_id)
+
+    action = request.POST.get("action", "")
+
+    if request.method == "POST":
+        if action == "upload":
+            return _handle_upload(request, brand)
+        if action == "delete":
+            return _handle_delete(request, brand)
+        if action == "extract":
+            return _handle_extract(request, brand)
+
+    documents = brand.documents.all().order_by("-uploaded_at") if brand else []
+    return render(request, "upload.html", _ctx(request, brand=brand, documents=documents))
+
+
+def _handle_upload(request, brand):
+    """Process a file upload for the given brand."""
+    if brand is None:
+        messages.error(request, "Select a brand before uploading.")
+        return redirect("/")
+
+    uploaded = request.FILES.get("file")
+    if not uploaded:
+        messages.error(request, "No file selected.")
+        return redirect(f"/?brand={brand.pk}")
+
+    name = uploaded.name or ""
+    ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+
+    if ext not in ALLOWED_EXTENSIONS:
+        messages.error(request, f"Unsupported file type '.{ext}'. Accepted: pdf, docx, txt, png.")
+        return redirect(f"/?brand={brand.pk}")
+
+    if uploaded.size > MAX_UPLOAD_BYTES:
+        messages.error(request, "File exceeds the 20 MB size limit.")
+        return redirect(f"/?brand={brand.pk}")
+
+    if ext in MIME_MAGIC:
+        header = uploaded.read(8)
+        uploaded.seek(0)
+        if not header.startswith(MIME_MAGIC[ext]):
+            messages.error(request, f"File content does not match the '{ext}' format.")
+            return redirect(f"/?brand={brand.pk}")
+
+    try:
+        extracted, was_truncated = extract_text(uploaded, ext)
+    except ValueError as exc:
+        messages.error(request, str(exc))
+        return redirect(f"/?brand={brand.pk}")
+
+    uploaded.seek(0)
+    Document.objects.create(
+        brand=brand,
+        file=uploaded,
+        filename=uploaded.name,
+        file_type=ext,
+        extracted_text=extracted,
+        truncated=was_truncated,
+    )
+
+    msg = f"'{uploaded.name}' uploaded and text extracted."
+    if was_truncated:
+        msg += " Text was truncated at 12,000 characters."
+    messages.success(request, msg)
+    return redirect(f"/?brand={brand.pk}")
+
+
+def _handle_delete(request, brand):
+    """Delete a document by pk from POST data."""
+    if brand is None:
+        messages.error(request, "Brand not found.")
+        return redirect("/")
+
+    doc_id = request.POST.get("document_id")
+    doc = get_object_or_404(Document, pk=doc_id, brand=brand)
+    filename = doc.filename
+    doc.delete()
+    messages.success(request, f"'{filename}' deleted.")
+    return redirect(f"/?brand={brand.pk}")
+
+
+def _handle_extract(request, brand):
+    """Trigger Claude signature extraction for the brand."""
+    if brand is None:
+        messages.error(request, "Brand not found.")
+        return redirect("/")
+
+    documents = list(brand.documents.all())
+    if not documents:
+        messages.error(request, "Upload at least one document before extracting a signature.")
+        return redirect(f"/?brand={brand.pk}")
+
+    previous_existed = brand.signature is not None
+    texts = [doc.extracted_text for doc in documents]
+
+    try:
+        signature = extract_signature(texts)
+    except ClaudeServiceError as exc:
+        messages.error(request, f"Claude API error: {exc}")
+        return redirect(f"/?brand={brand.pk}")
+
+    brand.signature = signature
+    brand.save(update_fields=["signature"])
+
+    if previous_existed:
+        messages.success(request, "Signature re-extracted and updated.")
+    else:
+        messages.success(request, "Tone-of-voice signature extracted successfully.")
+    return redirect(f"/?brand={brand.pk}")
+
+
+# ---------------------------------------------------------------------------
+# Transform view  /transform/
+# ---------------------------------------------------------------------------
+
+@require_http_methods(["GET", "POST"])
+def transform_view(request):
+    """Transform view — rewrite text in a brand's tone-of-voice.
+
+    GET  — render transform form.
+    POST — run transformation via Claude and display results.
+    """
+    brand_id = request.POST.get("brand_id") or request.GET.get("brand")
+    brand = None
+    if brand_id:
+        brand = get_object_or_404(Brand, pk=brand_id)
+
+    original = ""
+    transformed = ""
+
+    if request.method == "POST":
+        text = (request.POST.get("text") or "").strip()
+        if not text:
+            messages.error(request, "Enter some text to transform.")
+        elif brand is None:
+            messages.error(request, "Select a brand first.")
+        elif not brand.signature:
+            messages.error(request, "No signature for this brand. Run extraction on the Upload page first.")
+        else:
+            try:
+                original = text
+                transformed = transform_text(text, brand.signature)
+            except ClaudeServiceError as exc:
+                messages.error(request, f"Claude API error: {exc}")
+
+    return render(request, "transform.html", _ctx(
+        request,
+        brand=brand,
+        original=original,
+        transformed=transformed,
+    ))

--- a/tonofvoice/settings.py
+++ b/tonofvoice/settings.py
@@ -78,6 +78,7 @@ USE_I18N = True
 USE_TZ = True
 
 STATIC_URL = "static/"
+STATICFILES_DIRS = [BASE_DIR / "core" / "static"]
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 

--- a/tonofvoice/urls.py
+++ b/tonofvoice/urls.py
@@ -4,7 +4,11 @@ from django.conf import settings
 from django.conf.urls.static import static
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
+from core.views import transform_view, upload_view
+
 urlpatterns = [
+    path("", upload_view, name="upload"),
+    path("transform/", transform_view, name="transform"),
     path("admin/", admin.site.urls),
     path("api/", include("core.urls")),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),


### PR DESCRIPTION
## Summary
  - `upload_view` — brand selector, file upload form, document list with delete,
    Extract Signature button, current signature displayed per brand
  - `transform_view` — brand selector, textarea, side-by-side original/transformed panel,
    signature characteristics shown, "no signature yet" notice with link to upload
  - `base.html` — nav + Django messages block (success/error banners on every action)
  - Single stylesheet in `core/static/css/main.css` — no JS framework, no CSS framework
  - All actions use Django messages — no silent failures

  ## Checklist
  - [x] Both views render with no template errors
  - [x] File upload shows Django message on success and on error
  - [x] Truncation flagged in upload success message
  - [x] Extraction trigger shows result via Django message
  - [x] Transform view shows both original and transformed text side by side
  - [x] "No signature yet" state handled gracefully with link to upload page
  - [x] 57 tests pass — 0 regressions
  - [x] `manage.py check` — 0 issues
